### PR TITLE
feat: add a version overview to stdout

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,13 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 'amd64', 'arm64']
-    name: Build on Ubuntu 22.04 for linux/${{ matrix.version }}
+        architecture: [ 'amd64', 'arm64']
+    name: Build on Ubuntu 22.04 for linux/${{ matrix.architecture }}
     env:
       os: "ubuntu"
       version: "22.04"
       alias: "jammy"
-      platform: "linux/${{ matrix.version }}"
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU 
@@ -43,9 +42,9 @@ jobs:
         with:
           context: ./Dockerfiles/${{ env.os }}/${{ env.version }}
           file: ./Dockerfiles/${{ env.os }}/${{ env.version }}/Dockerfile
-          platforms: ${{ env.platform }}
+          platforms: "linux/${{ matrix.architecture }}"
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            public.ecr.aws/s6w2n1r6/codebuild-${{ matrix.version }}-${{ env.os }}:latest
-            public.ecr.aws/s6w2n1r6/codebuild-${{ matrix.version }}-${{ env.os }}:${{ env.version }}
-            public.ecr.aws/s6w2n1r6/codebuild-${{ matrix.version }}-${{ env.os }}:${{ env.alias }}
+            public.ecr.aws/s6w2n1r6/codebuild-${{ matrix.architecture }}-${{ env.os }}:latest
+            public.ecr.aws/s6w2n1r6/codebuild-${{ matrix.architecture }}-${{ env.os }}:${{ env.version }}
+            public.ecr.aws/s6w2n1r6/codebuild-${{ matrix.architecture }}-${{ env.os }}:${{ env.alias }}

--- a/Dockerfiles/ubuntu/22.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/22.04/entrypoint.sh
@@ -3,33 +3,38 @@
 set -eu
 
 function setup_go_version {
-    # configure goenv version
-    echo "configuring goenv version..."
+    echo "configuring goenv to use go version $1..."
 
     export GOENV_ROOT="$HOME/.goenv"
     export PATH="$GOENV_ROOT/bin:$PATH"
     eval "$(goenv init -)"
 
-    goenv install $DEFAULT_GO_VERSION
-    goenv global $DEFAULT_GO_VERSION
-    echo "running $(go version)"
+    goenv install $1
+    goenv global $1
 }
 
 function setup_node_version {
-    echo "configuring npm version..."
+    echo "configuring nvm to use node version $1..."
 
     export NVM_DIR=$HOME/.nvm;
 
     source $NVM_DIR/nvm.sh;
-    nvm install --no-progress $DEFAULT_NODE_VERSION
-    nvm alias default $DEFAULT_NODE_VERSION
+    nvm install --no-progress $1
+    nvm alias default $1
     nvm use default
-
-    echo "running node version $(node -v)"
-    echo "running npm version $(npm -v)"
 }
 
-setup_go_version
-setup_node_version
+setup_go_version $DEFAULT_GO_VERSION
+setup_node_version $DEFAULT_NODE_VERSION
+
+echo ""
+echo "==============================================="
+echo "go version: $(go version)"
+echo "node version: $(node -v)"
+echo "npm version: $(npm -v)"
+echo "aws-cli version: $(aws --version)"
+echo "python3 version: $(python3 --version)"
+echo "==============================================="
+echo ""
 
 eval "$@"

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ This is a selection of container images preinstalled with `goenv` and `nvm` so t
 
 ### linux/amd64
 
-| Operating System             | Docker Hub Repo                                                                                 | Docker Hub Tags             |
+| Operating System             | Public ECR Repo                                                                                 | Tags             |
 | ---------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------- |
 | Ubuntu 22.04 (Jammy Jellyfish)   | [public.ecr.aws/moia-oss/codebuild-amd64-ubuntu](https://gallery.ecr.aws/moia-oss/codebuild-amd64-ubuntu)           | 22.04, jammy, latest        |
 
 ### linux/arm64
 
-| Operating System             | Docker Hub Repo                                                                                 | Docker Hub Tags             |
+| Operating System             | Public ECR Repo                                                                                 | Tags             |
 | ---------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------- |
 | Ubuntu 22.04 (Jammy Jellyfish)   | [public.ecr.aws/moia-oss/codebuild-arm64-ubuntu](https://gallery.ecr.aws/moia-oss/codebuild-arm64-ubuntu)           | 22.04, jammy, latest        |
 


### PR DESCRIPTION
This PR adds a version overview on container startup:

```
Installing Go Linux 64bit 1.18.3...
Installed Go Linux 64bit 1.18.3 to /root/.goenv/versions/1.18.3

configuring nvm to use node version 14.20.0...
Downloading and installing node v14.20.0...
Downloading https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-x64.tar.xz...
Computing checksum with sha256sum
Checksums matched!
Now using node v14.20.0 (npm v6.14.17)
Creating default alias: default -> 14.20.0 (-> v14.20.0)
default -> 14.20.0 (-> v14.20.0)
Now using node v14.20.0 (npm v6.14.17)

===============================================
go version: go version go1.18.3 linux/amd64
node version: v14.20.0
npm version: 6.14.17
aws-cli version: aws-cli/1.25.25 Python/3.10.4 Linux/5.18.7-200.fc36.x86_64 botocore/1.27.25
python3 version: Python 3.10.4
===============================================
```