### PR TITLE
chore(ci): build images weekly instead of daily

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,7 +1,7 @@
 name: pipeline
 on:
   schedule:
-    - cron:  '0 8 * * *'
+    - cron:  '0 8 * * 1'
   push:
     branches:
       - 'main'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a selection of container images preinstalled with `goenv` and `n` so tha
 
 ## Supported Operating Systems
 
-> Container images are automatically rebuilt and published to public ECR repositories daily (8AM)
+> Container images are automatically rebuilt and published to public ECR repositories weekly (8AM UTC)
 
 
 ### linux/amd64


### PR DESCRIPTION
This PR will adjust the Github Actions Workflow to auto-trigger every week on monday 8 AM UTC