### PR TITLE
(MOIA-62182) Workaround entrypoint override

### DIFF
--- a/Dockerfiles/ubuntu/22.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/22.04/entrypoint.sh
@@ -28,7 +28,7 @@ echo "go version: $(go version)"
 echo "nodejs version: $(node -v)"
 echo "npm version: $(npm -v)"
 echo "aws-cli version: $(aws --version)"
-echo "aws-cdk version:" $(cdk --version)
+echo "aws-cdk version:" "$(cdk --version)"
 echo "python3 version: $(python3 --version)"
 echo "==============================================="
 echo ""

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ podman run --rm -it \
     public.ecr.aws/moia-oss/codebuild-ubuntu:latest
 ```
 
+### Codebuild
+
+AWS Codebuild overrides the `ENTRYPOINT` defined by the dockerfile. This means if you want to use a non-default version
+for any language you need to set them yourself. This can be easily done by running the included 
+`/entrypoint/entrypoint.sh` script, which will respect the environment variables mentioned above.
+
+Alternatively you could call `goenv` and `n` yourself directly.
+
 ## Examples
 
 Cloudformation Example:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ DeploySomething:
         Type: CODEPIPELINE
         BuildSpec: !Sub |
           version: 0.2
-          ... 
+          phases:
+            build:
+              commands:
+                - /entrypoint/entrypoint.sh
+                ... 
 ```
 
 CDK TypeScript example:


### PR DESCRIPTION
Unfortunately there doesn't seem to be any automatic way around this, so the only solution is to call the entrypoint script yourself