### PR TITLE
Set default Go version to v1.19

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # mentioned account names will be requested for
 # review when someone opens a pull request.
-*  @oppermax @msiuts @djablonski-moia @snowiow @guusvw @cbrgm
+*  @oppermax @msiuts @djablonski-moia @snowiow @guusvw @cbrgm @uberbinge

--- a/Dockerfiles/ubuntu/22.04/Dockerfile
+++ b/Dockerfiles/ubuntu/22.04/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer="MOIA GmbH" \
 # -----------------------Begin: environment -----------------------
 # Language Version
 
-ENV DEFAULT_GO_VERSION="1.18"
+ENV DEFAULT_GO_VERSION="1.19"
 ENV DEFAULT_NODEJS_VERSION="16"
 ENV DEFAULT_JAVA_VERSION="11"
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a selection of container images preinstalled with `goenv` and `n` so tha
 
 | Platform                        | Major Versions   | Environment Variable | Default Version |
 | ------------------------------- | ---------------- | -------------------- | --------------- |
-| Go                              | 1.17, 1.18, 1.19 | `GO_VERSION`         | 1.18            |
+| Go                              | 1.18, 1.19, 1.20 | `GO_VERSION`         | 1.19            |
 | NodeJS                          | 14, 16           | `NODEJS_VERSION`     | 14              |
 | Java Development Kit (Corretto) | 11, 17           | `JAVA_VERSION`       | 11              |
 
@@ -67,7 +67,7 @@ you can overwrite the default versions and use specific ones by passing the vers
 
 ```bash
 podman run --rm -it \
-    -e GO_VERSION="1.18" \
+    -e GO_VERSION="1.20" \
     -e NODEJS_VERSION="14" \
     public.ecr.aws/moia-oss/codebuild-ubuntu:latest
 ```
@@ -100,7 +100,7 @@ DeploySomething:
         PrivilegedMode: true
         EnvironmentVariables:
           - Name: GO_VERSION
-            Value: "1.18"
+            Value: "1.20"
           - Name: NODEJS_VERSION
             Value: "14"
             ...
@@ -155,7 +155,7 @@ new codepipeline.Pipeline(this, 'my-pipeline-id', {
                 },
                 GO_VERSION: {
                   type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
-                  value: '1.18',
+                  value: '1.20',
                 },
               },
             },


### PR DESCRIPTION
- feat: set Go 1.19 as default Go version
- docs: update documentation and examples
